### PR TITLE
Use https URL to git repo

### DIFF
--- a/sundown.cabal
+++ b/sundown.cabal
@@ -15,7 +15,7 @@ Description:
 
 source-repository head
   type:     git
-  location: git://github.com/bitonic/sundown.git
+  location: https://github.com/bitonic/sundown
 
 Library
   Hs-Source-Dirs:       src


### PR DESCRIPTION
That way we get a clickable link on Hackage, and it still works with git
clone..
